### PR TITLE
Use only byte strings when generating Urllib2 Requests

### DIFF
--- a/pyexchange/connection.py
+++ b/pyexchange/connection.py
@@ -5,6 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");?you may not use 
 Unless required by applicable law or agreed to in writing, software?distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
 import logging
+import sys
 from ntlm import HTTPNtlmAuthHandler
 
 try:
@@ -81,8 +82,12 @@ class ExchangeNTLMAuthConnection(ExchangeBaseConnection):
     # lxml tostring returns str in Python 2, and bytes in python 3
     # if XML is actually unicode, urllib2 will barf.
     # Oddly enough this only seems to be a problem in 2.7. 2.6 doesn't seem to care.
-    if isinstance(body, str):
-      body = body.decode(encoding)
+    if sys.version_info < (3, 0):
+      if isinstance(body, unicode):
+        body = body.encode(encoding)
+    else:
+      if isinstance(body, str):
+        body = body.encode(encoding)
 
     request = urllib2.Request(self.url, body)
 


### PR DESCRIPTION
```
- Urllib2 requests should always be passed byte strings as recommended by http://stackoverflow.com/questions/16670140/how-to-send-utf-8-content-in-a-urllib2-request
- This fixes an issue where python is implicity encoding unicode strings in ASCII before passing the data through the socket raising an UnicodeEncodeError
```
