### PR TITLE
Use byte strings when generating the request for the url as well

### DIFF
--- a/pyexchange/connection.py
+++ b/pyexchange/connection.py
@@ -79,17 +79,24 @@ class ExchangeNTLMAuthConnection(ExchangeBaseConnection):
     if not self.opener:
       self.opener = self.build_opener()
 
+    url = self.url
+
     # lxml tostring returns str in Python 2, and bytes in python 3
     # if XML is actually unicode, urllib2 will barf.
     # Oddly enough this only seems to be a problem in 2.7. 2.6 doesn't seem to care.
+    # The url used should be a bytestring as well. 2.6 doesn't care about this but 2.7 does.
     if sys.version_info < (3, 0):
       if isinstance(body, unicode):
         body = body.encode(encoding)
+      if isinstance(url, unicode):
+        url = url.encode(encoding)
     else:
       if isinstance(body, str):
         body = body.encode(encoding)
+      if isinstance(url, str):
+        url = url.encode(encoding)
 
-    request = urllib2.Request(self.url, body)
+    request = urllib2.Request(url, body)
 
     if headers:
       for header in headers:


### PR DESCRIPTION
When generating requests, it is recommended to use byte strings for all parameters. We converted the body to a byte string but forgot the case where the url maybe in unicode as well.
