### PR TITLE
Fix convert_datetime_to_utc() test.

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,9 +14,11 @@ def test_converting_non_tz_aware_date_returns_tz_aware():
   assert utc_time.tzinfo is None
   assert convert_datetime_to_utc(utc_time) == datetime(year=2014, month=1, day=1, hour=1, minute=1, second=1, tzinfo=utc)
 
-@mark.skipif(True, reason="Failing test, need to figure out which is wrong: test or code :3")
 def test_converting_tz_aware_date_returns_tz_aware_date():
-  pacific_time = datetime(year=2014, month=4, day=1, hour=1, minute=0, second=0, tzinfo=timezone("US/Pacific"))
-  utc_time = datetime(year=2014, month=1, day=1, hour=8, minute=0, second=0, tzinfo=utc)
+  # US/Pacific timezone is UTC-07:00 (In April we are in DST)
+  # We use localize() because according to the pytz documentation, using the tzinfo
+  # argument of the standard datetime constructors does not work for timezones with DST.
+  pacific_time = timezone("US/Pacific").localize(datetime(year=2014, month=4, day=1, hour=1, minute=0, second=0))
+  utc_time = utc.localize(datetime(year=2014, month=4, day=1, hour=8, minute=0, second=0))
 
   assert convert_datetime_to_utc(pacific_time) == utc_time


### PR DESCRIPTION
The test had two flaws:
1. The actual date was different (4/1 vs 1/1)
2. The time offset in the test was not correct (UTC-07:00 instead of
   UTC-08:00)
