### PR TITLE
python3 has no unicode builtin

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -258,6 +258,14 @@ You can pickle events if you need to serialize them. (We do this to send invites
     print rehydrated_event.subject # "80s Movie Night"
 
 
+To disable SSL certificate validation (e.g. when using corporate intranet) use this class (as per `requests doc <http://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification>`_): ::
+
+    class UnverifiedConnection(ExchangeNTLMAuthConnection):
+        def build_session(self):
+            super().build_session()
+            self.session.verify = False
+
+
 Changelog
 ---------
 

--- a/pyexchange/base/folder.py
+++ b/pyexchange/base/folder.py
@@ -79,6 +79,15 @@ class BaseExchangeFolder(object):
     if value in self.FOLDER_TYPES:
       self._folder_type = value
 
+  @property
+  def display_name(self):
+    """ **Read-only.** The internal id Exchange uses to refer to the parent folder. """
+    return self._display_name
+
+  @display_name.setter
+  def display_name(self, value):
+    self._display_name = value
+  
   def _update_properties(self, properties):
     self._track_dirty_attributes = False
     for key in properties:
@@ -102,3 +111,6 @@ class BaseExchangeFolder(object):
 
     if not self.parent_id:
       raise ValueError("Folder has no parent_id")
+
+  def __str__(self):
+    return "%s %s %s %s" % (self.__class__, self.display_name, self.folder_type, self.id)

--- a/pyexchange/base/mail.py
+++ b/pyexchange/base/mail.py
@@ -1,0 +1,16 @@
+"""
+(c) 2013 LinkedIn Corp. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");?you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software?distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+"""
+
+class BaseExchangeMailService(object):
+
+    def __init__(self, service):
+        self.service = service
+
+    def list_mails(self, *args, **kwargs):
+        raise NotImplementedError
+
+

--- a/pyexchange/base/soap.py
+++ b/pyexchange/base/soap.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from pytz import utc
 
 from ..exceptions import FailedExchangeException
+from pyexchange.exchange2010 import soap_request
 
 SOAP_NS = u'http://schemas.xmlsoap.org/soap/envelope/'
 
@@ -25,8 +26,9 @@ class ExchangeServiceSOAP(object):
 
   EXCHANGE_DATE_FORMAT = u"%Y-%m-%dT%H:%M:%SZ"
 
-  def __init__(self, connection):
+  def __init__(self, connection, version=u'Exchange2010'):
     self.connection = connection
+    self.version = version 
 
   def send(self, xml, headers=None, retries=4, timeout=30, encoding="utf-8"):
     request_xml = self._wrap_soap_xml_request(xml)
@@ -66,7 +68,9 @@ class ExchangeServiceSOAP(object):
     return response
 
   def _wrap_soap_xml_request(self, exchange_xml):
-    root = S.Envelope(S.Body(exchange_xml))
+    root = S.Envelope(
+      S.Header(soap_request.exchange_header(version=self.version)),
+      S.Body(exchange_xml))
     return root
 
   def _parse_date(self, date_string):

--- a/pyexchange/exchange2010/soap_request.py
+++ b/pyexchange/exchange2010/soap_request.py
@@ -9,7 +9,8 @@ from ..utils import convert_datetime_to_utc
 
 import sys
 if sys.version_info[0] == 3:
-	unicode = str
+  unicode = str
+  basestring = str
 
 MSG_NS = u'http://schemas.microsoft.com/exchange/services/2006/messages'
 TYPE_NS = u'http://schemas.microsoft.com/exchange/services/2006/types'
@@ -23,6 +24,7 @@ T = ElementMaker(namespace=TYPE_NS, nsmap=NAMESPACES)
 EXCHANGE_DATETIME_FORMAT = u"%Y-%m-%dT%H:%M:%SZ"
 EXCHANGE_DATE_FORMAT = u"%Y-%m-%d"
 
+# http://msdn.microsoft.com/en-us/library/microsoft.exchange.webservices.data.wellknownfoldername%28v=exchg.80%29.aspx
 DISTINGUISHED_IDS = (
   'calendar', 'contacts', 'deleteditems', 'drafts', 'inbox', 'journal', 'notes', 'outbox', 'sentitems',
   'tasks', 'msgfolderroot', 'root', 'junkemail', 'searchfolders', 'voicemail', 'recoverableitemsroot',
@@ -32,9 +34,9 @@ DISTINGUISHED_IDS = (
 )
 
 
-def exchange_header():
+def exchange_header(version=u'Exchange2010'):
 
-  return T.RequestServerVersion({u'Version': u'Exchange2010'})
+  return T.RequestServerVersion({u'Version': version})
 
 
 def resource_node(element, resources):
@@ -120,6 +122,9 @@ def get_item(exchange_id, format=u"Default"):
   return root
 
 def get_calendar_items(format=u"Default", start=None, end=None, max_entries=999999):
+  """
+    http://msdn.microsoft.com/en-us/library/office/dn535506%28v=exchg.150%29.aspx#bk_getews
+  """
   start = start.strftime(EXCHANGE_DATETIME_FORMAT)
   end = end.strftime(EXCHANGE_DATETIME_FORMAT)
 

--- a/pyexchange/exchange2010/soap_request.py
+++ b/pyexchange/exchange2010/soap_request.py
@@ -7,6 +7,10 @@ Unless required by applicable law or agreed to in writing, software?distributed 
 from lxml.builder import ElementMaker
 from ..utils import convert_datetime_to_utc
 
+import sys
+if sys.version_info[0] == 3:
+	unicode = str
+
 MSG_NS = u'http://schemas.microsoft.com/exchange/services/2006/messages'
 TYPE_NS = u'http://schemas.microsoft.com/exchange/services/2006/types'
 SOAP_NS = u'http://schemas.xmlsoap.org/soap/envelope/'

--- a/pyexchange/exchange2010/soap_request_mail.py
+++ b/pyexchange/exchange2010/soap_request_mail.py
@@ -1,0 +1,71 @@
+"""
+(c) 2013 LinkedIn Corp. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");?you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software?distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+"""
+
+from .soap_request import M, T, DISTINGUISHED_IDS
+
+import sys
+if sys.version_info[0] == 3:
+    unicode = str
+    basestring = str
+
+
+def get_mail_items(folder_id='inbox', format=u"Default", query=None, max_entries=1000):
+    """
+      :param str format: IdOnly or Default or AllProperties
+                         - see `doc <http://msdn.microsoft.com/en-us/library/aa580545%28v=exchg.140%29.aspx>`_
+      :param str query: advanced query, example: `HasAttachments:true Subject:'Message with Attachments' Kind:email`
+                        - see `doc <http://msdn.microsoft.com/en-us/library/ee693615%28v=exchg.140%29.aspx>`_
+      :param max_entries: defaults to 1000 as exchange won't return more under default settings
+    """
+    # http://msdn.microsoft.com/en-us/library/aa566107%28v=exchg.140%29.aspx         FindItem operation
+    # http://msdn.microsoft.com/en-us/library/aa566370%28v=exchg.140%29.aspx         FindItem XML
+    # http://msdn.microsoft.com/en-us/library/office/dn579420%28v=exchg.150%29.aspx  FindItem + AQS
+    xml_fid = T.DistinguishedFolderId(Id=folder_id) if folder_id in DISTINGUISHED_IDS else T.FolderId(Id=folder_id)
+    root = M.FindItem(
+        {u'Traversal': u'Shallow'},
+        M.ItemShape(
+            T.BaseShape(format),
+            T.AdditionalProperties(
+                T.FieldURI(FieldURI=u'item:Subject'),
+                T.FieldURI(FieldURI=u'item:DateTimeReceived'),
+                T.FieldURI(FieldURI=u'item:Size'),
+                T.FieldURI(FieldURI=u'item:Importance'),
+                # T.FieldURI(FieldURI=u'item:Attachments'),
+                T.FieldURI(FieldURI=u'message:IsRead'),
+                )
+        ),
+        # <FractionalPageItemView MaxEntriesReturned="" Numerator="" Denominator=""/>
+        # <m:IndexedPageItemView MaxEntriesReturned="10" Offset="0" BasePoint="Beginning" />
+        M.IndexedPageItemView(MaxEntriesReturned=unicode(max_entries), Offset="0", BasePoint="Beginning"),
+        M.SortOrder(
+            T.FieldOrder(
+                T.FieldURI(FieldURI=u'item:DateTimeReceived'),
+                Order=u'Descending'
+            )
+        ),
+        M.ParentFolderIds(xml_fid),
+        M.QueryString(query) if query else ' '
+    )
+    return root
+
+
+def get_attachment(aid):
+    """
+    The GetAttachment operation is used to retrieve existing attachments on items in the Exchange store.
+    See `doc <http://msdn.microsoft.com/en-us/library/aa494316%28v=exchg.140%29.aspx>`
+    
+    Can raise FailedExchangeException: Exchange Fault (ErrorInvalidIdNotAnItemAttachmentId) from Exchange server
+    """
+    root = M.GetAttachment(
+        M.AttachmentShape(),
+        M.AttachmentIds(
+            T.AttachmentId(Id=aid)
+        )
+    )
+    return root
+
+


### PR DESCRIPTION
This fixes python3 compatibility (at least for getting events in date range as per the tutorial)
