### PR TITLE
Handle empty email for attendees.

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,3 +4,4 @@ pytest-cov
 httpretty
 flake8
 mock
+requests_ntlm

--- a/pyexchange/exchange2010/__init__.py
+++ b/pyexchange/exchange2010/__init__.py
@@ -647,7 +647,8 @@ class Exchange2010CalendarEvent(BaseExchangeCalendarEvent):
       if u'last_response' not in attendee_properties:
         attendee_properties[u'last_response'] = None
 
-      result.append(attendee_properties)
+      if u'email' in attendee_properties:
+        result.append(attendee_properties)
 
     return result
 
@@ -683,7 +684,8 @@ class Exchange2010CalendarEvent(BaseExchangeCalendarEvent):
       if u'last_response' not in attendee_properties:
         attendee_properties[u'last_response'] = None
 
-      result.append(attendee_properties)
+      if u'email' in attendee_properties:
+        result.append(attendee_properties)
 
     optional_attendees = response.xpath(u'//m:Items/t:CalendarItem/t:OptionalAttendees/t:Attendee', namespaces=soap_request.NAMESPACES)
 
@@ -694,7 +696,8 @@ class Exchange2010CalendarEvent(BaseExchangeCalendarEvent):
       if u'last_response' not in attendee_properties:
         attendee_properties[u'last_response'] = None
 
-      result.append(attendee_properties)
+      if u'email' in attendee_properties:
+        result.append(attendee_properties)
 
     return result
 


### PR DESCRIPTION
Currently the application crashes if the email is not set for attendees/resources.  This change will not add attendees with no emails to the attendee/resource list when returned from the server.