### PR TITLE
Implemented multi-calendar support for list_events().

### DIFF
--- a/pyexchange/exchange2010/__init__.py
+++ b/pyexchange/exchange2010/__init__.py
@@ -92,14 +92,15 @@ class Exchange2010CalendarService(BaseExchangeCalendarService):
     return Exchange2010CalendarEvent(service=self.service, calendar_id=self.calendar_id, **properties)
 
   def list_events(self, start=None, end=None, details=False, delegate_for=None):
-    return Exchange2010CalendarEventList(service=self.service, start=start, end=end, details=details, delegate_for=delegate_for)
+    return Exchange2010CalendarEventList(service=self.service, calendar_id=self.calendar_id, start=start, end=end, details=details, delegate_for=delegate_for)
 
 
 class Exchange2010CalendarEventList(object):
   """
   Creates & Stores a list of Exchange2010CalendarEvent items in the "self.events" variable.
   """
-  def __init__(self, service=None, start=None, end=None, details=False, delegate_for=None):
+
+  def __init__(self, service=None, calendar_id=u'calendar', start=None, end=None, details=False, delegate_for=None):
     self.service = service
     self.count = 0
     self.start = start
@@ -110,7 +111,7 @@ class Exchange2010CalendarEventList(object):
     self.delegate_for = delegate_for
 
     # This request uses a Calendar-specific query between two dates.
-    body = soap_request.get_calendar_items(format=u'AllProperties', start=self.start, end=self.end, delegate_for=self.delegate_for)
+    body = soap_request.get_calendar_items(format=u'AllProperties', calendar_id=calendar_id, start=self.start, end=self.end, delegate_for=self.delegate_for)
     response_xml = self.service.send(body)
     self._parse_response_for_all_events(response_xml)
 

--- a/pyexchange/exchange2010/soap_request.py
+++ b/pyexchange/exchange2010/soap_request.py
@@ -116,19 +116,23 @@ def get_item(exchange_id, format=u"Default"):
   )
   return root
 
-
-def get_calendar_items(format=u"Default", start=None, end=None, max_entries=999999, delegate_for=None):
+def get_calendar_items(format=u"Default", calendar_id=u'calendar', start=None, end=None, max_entries=999999, delegate_for=None):
   start = start.strftime(EXCHANGE_DATETIME_FORMAT)
   end = end.strftime(EXCHANGE_DATETIME_FORMAT)
-  if delegate_for is None:
-    target = M.ParentFolderIds(T.DistinguishedFolderId(Id=u"calendar"))
-  else:
-    target = M.ParentFolderIds(
-      T.DistinguishedFolderId(
-        {'Id': 'calendar'},
-        T.Mailbox(T.EmailAddress(delegate_for))
+
+  if calendar_id == u'calendar':
+    if delegate_for is None:
+      target = M.ParentFolderIds(T.DistinguishedFolderId(Id=calendar_id))
+    else:
+      target = M.ParentFolderIds(
+        T.DistinguishedFolderId(
+          {'Id': 'calendar'},
+          T.Mailbox(T.EmailAddress(delegate_for))
+        )
       )
-    )
+  else:
+    target = M.ParentFolderIds(T.FolderId(Id=calendar_id))
+
   root = M.FindItem(
     {u'Traversal': u'Shallow'},
     M.ItemShape(


### PR DESCRIPTION
Using this awesome library I discovered that the calendar id passed to Exchange2010Service is ignored by list_events(). This pull request should fix this issue.

Since tests seems to be broken for Python 3.4 and I have only 3.4 installed, I could not run any tests.