### PR TITLE
Enable getting of master item also for type 'Exception'.

### DIFF
--- a/pyexchange/exchange2010/__init__.py
+++ b/pyexchange/exchange2010/__init__.py
@@ -383,14 +383,14 @@ class Exchange2010CalendarEvent(BaseExchangeCalendarEvent):
   def get_master(self):
     """
       get_master()
-      :raises InvalidEventType: When this method is called on an event that is not a Occurrence type.
+      :raises InvalidEventType: When this method is called on an event that is not a Occurrence or Exception type.
 
       This will return the master event to the occurrence.
 
       **Examples**::
 
         event = service.calendar().get_event(id='<event_id>')
-        print event.type  # If it prints out 'Occurrence' then that means we could get the master.
+        print event.type  # If it prints out 'Occurrence' (or 'Exception') then that means we could get the master.
 
         master = event.get_master()
         print master.type  # Will print out 'RecurringMaster'.
@@ -398,8 +398,8 @@ class Exchange2010CalendarEvent(BaseExchangeCalendarEvent):
 
     """
 
-    if self.type != 'Occurrence':
-      raise InvalidEventType("get_master method can only be called on a 'Occurrence' event type")
+    if self.type not in ('Occurrence','Exception'):
+      raise InvalidEventType("get_master method can only be called on a 'Occurrence' or 'Exception' event type")
 
     body = soap_request.get_master(exchange_id=self._id, format=u"AllProperties")
     response_xml = self.service.send(body)


### PR DESCRIPTION
Hi,

so far getting the master calendar item is limited to the 'Occurence' type, but I don't see why it should not work for the 'Exception' as well.
