### PR TITLE
Adding attachments to event

### DIFF
--- a/pyexchange/base/attachment.py
+++ b/pyexchange/base/attachment.py
@@ -16,6 +16,9 @@ class BaseExchangeAttachment(object):
   def _send_soap_request(self, body_type, include_mime_content, filter_html_content):
     raise NotImplementedError
 
+  def _send_delete_request(self):
+    raise NotImplementedError
+
   def _parse_response_for_get_attachment(root):
     raise NotImplementedError
 
@@ -30,6 +33,11 @@ class BaseExchangeAttachment(object):
     if not self._loaded:
       self.load()
     return self._name
+
+  def delete(self):
+    # Normal SOAP error handling should work here
+    self._send_delete_request()
+
 
   def load(self, body_type=None, include_mime_content=False, filter_html_content=False):
     # Defaults, only valid values

--- a/pyexchange/base/attachment.py
+++ b/pyexchange/base/attachment.py
@@ -1,0 +1,53 @@
+
+
+BODY_TYPE_BEST = u'Best'
+BODY_TYPE_HTML = u'HTML'
+BODY_TYPE_TEXT = u'Text'
+BODY_TYPES = [BODY_TYPE_BEST, BODY_TYPE_HTML, BODY_TYPE_TEXT]
+
+class BaseExchangeAttachment(object):
+  def __init__(self, service, attachment_id, load=False):
+    self.service = service
+    self.attachment_id = attachment_id
+    if not load:
+      self._loaded = False
+    else:
+      self.load()
+
+  def _send_soap_request(self, body_type, include_mime_content, filter_html_content):
+    raise NotImplementedError
+
+  def _parse_response_for_get_attachment(root):
+    raise NotImplementedError
+
+  @property
+  def content(self):
+    if not self._loaded:
+      self.load()
+    return self._content
+
+  @property
+  def name(self):
+    if not self._loaded:
+      self.load()
+    return self._name
+
+  def load(self, body_type=None, include_mime_content=False, filter_html_content=False):
+    # Defaults, only valid values
+    if body_type not in BODY_TYPES:
+      body_type = BODY_TYPE_BEST
+
+    include_mime_content = 'false'
+    if include_mime_content == True:
+      include_mime_content = 'true'
+
+    filter_html_content = 'false'
+    if filter_html_content == True:
+      filter_html_content = 'true'
+
+    # Send soap request
+    root = self._send_soap_request(body_type, include_mime_content, filter_html_content)
+    # Parse it (That'll have to be defined on child classes)
+    self._parse_response_for_get_attachment(root)
+    self._loaded = True
+    return self

--- a/pyexchange/base/attachment.py
+++ b/pyexchange/base/attachment.py
@@ -1,9 +1,8 @@
-
-
 BODY_TYPE_BEST = u'Best'
 BODY_TYPE_HTML = u'HTML'
 BODY_TYPE_TEXT = u'Text'
 BODY_TYPES = [BODY_TYPE_BEST, BODY_TYPE_HTML, BODY_TYPE_TEXT]
+
 
 class BaseExchangeAttachment(object):
   def __init__(self, service, attachment_id, load=False):
@@ -38,11 +37,11 @@ class BaseExchangeAttachment(object):
       body_type = BODY_TYPE_BEST
 
     include_mime_content = 'false'
-    if include_mime_content == True:
+    if include_mime_content is True:
       include_mime_content = 'true'
 
     filter_html_content = 'false'
-    if filter_html_content == True:
+    if filter_html_content is True:
       filter_html_content = 'true'
 
     # Send soap request

--- a/pyexchange/base/attachment.py
+++ b/pyexchange/base/attachment.py
@@ -7,7 +7,7 @@ BODY_TYPES = [BODY_TYPE_BEST, BODY_TYPE_HTML, BODY_TYPE_TEXT]
 class BaseExchangeAttachment(object):
   def __init__(self, service, attachment_id, load=False):
     self.service = service
-    self.attachment_id = attachment_id
+    self.id = attachment_id
     if not load:
       self._loaded = False
     else:

--- a/pyexchange/base/attachment.py
+++ b/pyexchange/base/attachment.py
@@ -38,7 +38,6 @@ class BaseExchangeAttachment(object):
     # Normal SOAP error handling should work here
     self._send_delete_request()
 
-
   def load(self, body_type=None, include_mime_content=False, filter_html_content=False):
     # Defaults, only valid values
     if body_type not in BODY_TYPES:

--- a/pyexchange/base/calendar.py
+++ b/pyexchange/base/calendar.py
@@ -302,6 +302,10 @@ class BaseExchangeCalendarEvent(object):
     if self.resources and len(self.resources) == 1:
       return self.resources[0]
 
+  @property
+  def attachments(self):
+    return self._attachments
+
   def validate(self):
     """ Validates that all required fields are present """
     if not self.start:

--- a/pyexchange/exchange2010/__init__.py
+++ b/pyexchange/exchange2010/__init__.py
@@ -986,12 +986,12 @@ class Exchange2010Attachment(BaseExchangeAttachment):
     return self.service.send(soap_request.delete_attachment(self.id))
 
   def _parse_response_for_get_attachment(self, root):
-    try:
-      self._name = root.xpath(u'//t:Name', namespaces=soap_request.NAMESPACES)[0].text
-    except IndexError:
-      raise ValueError('Unable to get item from Exchange')
-
-    try:
-      self._content = root.xpath(u'//t:Content', namespaces=soap_request.NAMESPACES)[0].text
-    except IndexError:
-      raise ValueError('Unable to get item from Exchange')
+    as_dict = self.service._xpath_to_dict(element=root, property_map={
+      u'_name': {
+        'xpath': u'//t:Name'
+      },
+      u'_content': {
+        'xpath': u'//t:Content'
+      }
+    }, namespace_map=soap_request.NAMESPACES)
+    self.__dict__.update(as_dict)

--- a/pyexchange/exchange2010/__init__.py
+++ b/pyexchange/exchange2010/__init__.py
@@ -555,7 +555,6 @@ class Exchange2010CalendarEvent(BaseExchangeCalendarEvent):
       return None, None
 
   def _parse_response_for_get_event(self, response):
-
     result = self._parse_event_properties(response)
 
     organizer_properties = self._parse_event_organizer(response)
@@ -563,6 +562,9 @@ class Exchange2010CalendarEvent(BaseExchangeCalendarEvent):
       if 'email' not in organizer_properties:
         organizer_properties['email'] = None
       result[u'organizer'] = ExchangeEventOrganizer(**organizer_properties)
+
+    attachment_ids = self._parse_event_attachments(response)
+    result[u'_attachments'] = [Exchange2010Attachment(self.service, attachment_id) for attachment_id in attachment_ids]
 
     attendee_properties = self._parse_event_attendees(response)
     result[u'_attendees'] = self._build_resource_dictionary([ExchangeEventResponse(**attendee) for attendee in attendee_properties])
@@ -658,6 +660,10 @@ class Exchange2010CalendarEvent(BaseExchangeCalendarEvent):
         result['recurrence'] = 'yearly'
 
     return result
+
+  def _parse_event_attachments(self, response):
+    attachments = response.xpath(u'//m:Items/t:CalendarItem/t:Attachments/t:FileAttachment/t:AttachmentId', namespaces=soap_request.NAMESPACES)
+    return [att.get('Id') for att in attachments]
 
   def _parse_event_organizer(self, response):
 

--- a/pyexchange/exchange2010/__init__.py
+++ b/pyexchange/exchange2010/__init__.py
@@ -162,15 +162,15 @@ class Exchange2010CalendarEventList(object):
     """
     log.debug(u"Loading all details")
     if self.count > 0:
-      # Now, empty out the events to prevent duplicates!
+        # Now, empty out the events to prevent duplicates!
       del(self.events[:])
 
-      # Send the SOAP request with the list of exchange ID values.
+    # Send the SOAP request with the list of exchange ID values.
       log.debug(u"Requesting all event details for events: {event_list}".format(event_list=str(self.event_ids)))
       body = soap_request.get_item(exchange_id=self.event_ids, format=u'AllProperties')
       response_xml = self.service.send(body)
 
-      # Re-parse the results for all the details!
+    # Re-parse the results for all the details!
       self._parse_response_for_all_events(response_xml)
 
     return self
@@ -326,13 +326,12 @@ class Exchange2010CalendarEvent(BaseExchangeCalendarEvent):
     if b64_data:
       try:
         base64.b64decode(b64_data)
-      # TypeError is raised by python 2, binascii.Error by p3
-      except (TypeError, binascii.Error):
+      except (TypeError, binascii.Error):  # TypeError is raised by python 2, binascii.Error by p3
         raise TypeError('Base 64 data seems to be invalid')
       else:
         data = b64_data
     else:
-      # file or file path?
+        # file or file path?
       try:
         binary = file.read()
       except AttributeError:
@@ -345,8 +344,7 @@ class Exchange2010CalendarEvent(BaseExchangeCalendarEvent):
 
     # Let's make sure that data is a string, not bytes, for XML reasons
     if type(data) == bytes:
-      # being b64 encoded, ascii should work fine
-      data = data.decode('ascii')
+      data = data.decode('ascii')  # being b64 encoded, ascii should work fine
 
     root = self.service.send(soap_request.create_attachment(self, file_name, data))
     # Find the id

--- a/pyexchange/exchange2010/__init__.py
+++ b/pyexchange/exchange2010/__init__.py
@@ -980,7 +980,7 @@ class Exchange2010Folder(BaseExchangeFolder):
 
 class Exchange2010Attachment(BaseExchangeAttachment):
   def _send_soap_request(self, body_type, include_mime_content, filter_html_content):
-    return self.service.send(soap_request.get_attachment(self.attachment_id, body_type, include_mime_content, filter_html_content))
+    return self.service.send(soap_request.get_attachment(self.id, body_type, include_mime_content, filter_html_content))
 
   def _parse_response_for_get_attachment(self, root):
     try:

--- a/pyexchange/exchange2010/__init__.py
+++ b/pyexchange/exchange2010/__init__.py
@@ -982,6 +982,9 @@ class Exchange2010Attachment(BaseExchangeAttachment):
   def _send_soap_request(self, body_type, include_mime_content, filter_html_content):
     return self.service.send(soap_request.get_attachment(self.id, body_type, include_mime_content, filter_html_content))
 
+  def _send_delete_request(self):
+    return self.service.send(soap_request.delete_attachment(self.id))
+
   def _parse_response_for_get_attachment(self, root):
     try:
       self._name = root.xpath(u'//t:Name', namespaces=soap_request.NAMESPACES)[0].text

--- a/pyexchange/exchange2010/soap_request.py
+++ b/pyexchange/exchange2010/soap_request.py
@@ -424,11 +424,12 @@ def get_attachment(attachment_id, body_type, include_mime_content, filter_html_c
       </soap:Body>
     </soap:Envelope>
     """
-    import logging
-    logger = logging.getLogger('pyexchange')
-    logger.debug(attachment_id, body_type, include_mime_content, filter_html_content)
     return M.GetAttachment(
-        M.AttachmentShape(),
+        M.AttachmentShape(
+            M.BodyType(body_type),
+            M.IncludeMimeContent(include_mime_content),
+            M.FilterHtmlContent(filter_html_content)
+        ),
         M.AttachmentIds(
             T.AttachmentId(Id=attachment_id)
         )

--- a/pyexchange/exchange2010/soap_request.py
+++ b/pyexchange/exchange2010/soap_request.py
@@ -435,6 +435,29 @@ def get_attachment(attachment_id, body_type, include_mime_content, filter_html_c
         )
     )
 
+def delete_attachment(event_id):
+    """
+    <?xml version="1.0" encoding="utf-8"?>
+    <soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+           xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+           xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+        <soap:Body>
+           <DeleteAttachment xmlns="http://schemas.microsoft.com/exchange/services/2006/messages"
+                  xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+               <AttachmentIds>
+                    <t:AttachmentId Id="AAAtAEFkbWluaX"/>
+                </AttachmentIds>
+            </DeleteAttachment>
+        </soap:Body>
+    </soap:Envelope>
+    """
+    return M.DeleteAttachment(
+        M.AttachmentIds(
+            T.AttachmentId(Id=event_id)
+        )
+    )
+
 def create_attachment(event, file_name, data):
     """ Create attachment
     https://msdn.microsoft.com/en-us/library/aa565877(v=exchg.140).aspx

--- a/pyexchange/exchange2010/soap_request.py
+++ b/pyexchange/exchange2010/soap_request.py
@@ -405,6 +405,60 @@ def new_event(event):
 
   return root
 
+def get_attachment(attachment_id, body_type, include_mime_content, filter_html_content):
+    """ Get attachment
+        https://msdn.microsoft.com/en-us/library/aa494316(v=exchg.140).aspx
+        <?xml version="1.0" encoding="utf-8"?>
+    <soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+      <soap:Body>
+        <GetAttachment xmlns="http://schemas.microsoft.com/exchange/services/2006/messages"
+        xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+          <AttachmentShape/>
+          <AttachmentIds>
+            <t:AttachmentId Id="AAAtAEFkbWluaX..."/>
+          </AttachmentIds>
+        </GetAttachment>
+      </soap:Body>
+    </soap:Envelope>
+    """
+    import logging
+    logger = logging.getLogger('pyexchange')
+    logger.debug(attachment_id, body_type, include_mime_content, filter_html_content)
+    return M.GetAttachment(
+        M.AttachmentShape(),
+        M.AttachmentIds(
+            T.AttachmentId(Id=attachment_id)
+        )
+    )
+
+def create_attachment(event, file_name, data):
+    """ Create attachment
+    https://msdn.microsoft.com/en-us/library/aa565877(v=exchg.140).aspx
+    <CreateAttachment xmlns="http://schemas.microsoft.com/exchange/services/2006/messages"
+                    xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+      <ParentItemId Id="AAAtAE..." ChangeKey="CQAAABYA..."/>
+      <Attachments>
+        <t:FileAttachment>
+          <t:Name>SomeFile</t:Name>
+          <t:Content>AQIDBAU=</t:Content>
+        </t:FileAttachment>
+      </Attachments>
+    </CreateAttachment>
+    """
+    if not event.change_key:
+      event.refresh_change_key()
+    return M.CreateAttachment(
+        M.ParentItemId(Id=event.id, ChangeKey=event.change_key),
+        M.Attachments(
+            T.FileAttachment(
+                T.Name(file_name),
+                T.Content(data)
+            )
+        )
+    )
 
 def delete_event(event):
     """

--- a/pyexchange/exchange2010/soap_request.py
+++ b/pyexchange/exchange2010/soap_request.py
@@ -116,6 +116,7 @@ def get_item(exchange_id, format=u"Default"):
   )
   return root
 
+
 def get_calendar_items(format=u"Default", calendar_id=u'calendar', start=None, end=None, max_entries=999999, delegate_for=None):
   start = start.strftime(EXCHANGE_DATETIME_FORMAT)
   end = end.strftime(EXCHANGE_DATETIME_FORMAT)
@@ -405,6 +406,7 @@ def new_event(event):
 
   return root
 
+
 def get_attachment(attachment_id, body_type, include_mime_content, filter_html_content):
     """ Get attachment
         https://msdn.microsoft.com/en-us/library/aa494316(v=exchg.140).aspx
@@ -435,6 +437,7 @@ def get_attachment(attachment_id, body_type, include_mime_content, filter_html_c
         )
     )
 
+
 def delete_attachment(event_id):
     """
     <?xml version="1.0" encoding="utf-8"?>
@@ -457,6 +460,7 @@ def delete_attachment(event_id):
             T.AttachmentId(Id=event_id)
         )
     )
+
 
 def create_attachment(event, file_name, data):
     """ Create attachment
@@ -483,6 +487,7 @@ def create_attachment(event, file_name, data):
             )
         )
     )
+
 
 def delete_event(event):
     """

--- a/tests/exchange2010/fixtures.py
+++ b/tests/exchange2010/fixtures.py
@@ -1731,6 +1731,27 @@ LIST_EVENTS_RESPONSE = u"""<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/
 
 ATTACHMENT_NAME = u"tëst strïnġ"
 
+DELETE_ATTACHMENT_RESPONSE = u"""<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Header>
+    <t:ServerVersionInfo MajorVersion="8" MinorVersion="0" MajorBuildNumber="662" MinorBuildNumber="0"
+                         xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"/>
+  </soap:Header>
+  <soap:Body>
+    <DeleteAttachmentResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
+                              xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
+                              xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
+      <m:ResponseMessages>
+        <m:DeleteAttachmentResponseMessage xsi:type="m:DeleteAttachmentResponseMessageType" ResponseClass="Success">
+          <m:ResponseCode>NoError</m:ResponseCode>
+          <m:RootItemId RootItemId="AAAtAEFkbWluaXN..." RootItemChangeKey="CQAAABYAA..."/>
+        </m:DeleteAttachmentResponseMessage>
+      </m:ResponseMessages>
+    </DeleteAttachmentResponse>
+  </soap:Body>
+</soap:Envelope>"""
 
 CREATE_ATTACHMENT_RESPONSE = u"""<?xml version="1.0" encoding="utf-8" ?>
 <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">

--- a/tests/exchange2010/fixtures.py
+++ b/tests/exchange2010/fixtures.py
@@ -206,6 +206,8 @@ UPDATED_RESOURCE = ExchangeEventResponse(name=u'ɱăğĭč čăřρĕt', email=u
 
 RESOURCE_WITH_NO_EMAIL_ADDRESS = ExchangeEventResponse(name=u'I am also bad', email=None, required=True, response=RESPONSE_UNKNOWN, last_response=None)
 
+ATTACHMENT_IDS = [u'ɱăğĭč čăřρĕt', u'flÿïnġ dïnösäür']
+
 GET_ITEM_RESPONSE = u"""<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
   <s:Header>
     <h:ServerVersionInfo xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" MajorVersion="14" MinorVersion="2" MajorBuildNumber="328" MinorBuildNumber="11"/>
@@ -395,6 +397,209 @@ GET_ITEM_RESPONSE = u"""<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/env
            optional_unknown=PERSON_OPTIONAL_UNKNOWN,
            resource=RESOURCE,
            conflict_event=TEST_CONFLICT_EVENT,
+           )
+
+GET_ITEM_WITH_ATTACHMENTS_RESPONSE = u"""<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+  <s:Header>
+    <h:ServerVersionInfo xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" MajorVersion="14" MinorVersion="2" MajorBuildNumber="328" MinorBuildNumber="11"/>
+  </s:Header>
+  <s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <m:GetItemResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+      <m:ResponseMessages>
+        <m:GetItemResponseMessage ResponseClass="Success">
+          <m:ResponseCode>NoError</m:ResponseCode>
+          <m:Items>
+            <t:CalendarItem>
+              <t:ItemId Id="{event.id}" ChangeKey="{event.change_key}"/>
+              <t:ParentFolderId Id="fooo" ChangeKey="bar"/>
+              <t:ItemClass>IPM.Appointment</t:ItemClass>
+              <t:Subject>{event.subject}</t:Subject>
+              <t:Sensitivity>Normal</t:Sensitivity>
+              <t:Body BodyType="HTML">{event.body}</t:Body>
+              <t:Body BodyType="Text">{event.body}</t:Body>
+              <t:Attachments>
+                <t:FileAttachment>
+                  <t:AttachmentId Id="{attachment_id1}"/>
+                  <t:Name>Some filename.txt</t:Name>
+                </t:FileAttachment>
+                <t:FileAttachment>
+                  <t:AttachmentId Id="{attachment_id2}"/>
+                  <t:Name>Some filename.txt</t:Name>
+                </t:FileAttachment>
+              </t:Attachments>
+              <t:DateTimeReceived>{event.start:%Y-%m-%dT%H:%M:%SZ}</t:DateTimeReceived>
+              <t:Size>1935</t:Size>
+              <t:Importance>Normal</t:Importance>
+              <t:IsSubmitted>false</t:IsSubmitted>
+              <t:IsDraft>false</t:IsDraft>
+              <t:IsFromMe>false</t:IsFromMe>
+              <t:IsResend>false</t:IsResend>
+              <t:IsUnmodified>false</t:IsUnmodified>
+              <t:DateTimeSent>{event.start:%Y-%m-%dT%H:%M:%SZ}</t:DateTimeSent>
+              <t:DateTimeCreated>{event.start:%Y-%m-%dT%H:%M:%SZ}</t:DateTimeCreated>
+              <t:ResponseObjects>
+                <t:CancelCalendarItem/>
+                <t:ForwardItem/>
+              </t:ResponseObjects>
+              <t:ReminderDueBy>{event.start:%Y-%m-%dT%H:%M:%SZ}</t:ReminderDueBy>
+              <t:ReminderIsSet>true</t:ReminderIsSet>
+              <t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart>
+              <t:DisplayCc/>
+              <t:DisplayTo/>
+              <t:HasAttachments>false</t:HasAttachments>
+              <t:Culture>en-US</t:Culture>
+              <t:Start>{event.start:%Y-%m-%dT%H:%M:%SZ}</t:Start>
+              <t:End>{event.end:%Y-%m-%dT%H:%M:%SZ}</t:End>
+              <t:IsAllDayEvent>false</t:IsAllDayEvent>
+              <t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus>
+              <t:Location>{event.location}</t:Location>
+              <t:IsMeeting>true</t:IsMeeting>
+              <t:IsCancelled>false</t:IsCancelled>
+              <t:IsRecurring>false</t:IsRecurring>
+              <t:MeetingRequestWasSent>false</t:MeetingRequestWasSent>
+              <t:IsResponseRequested>true</t:IsResponseRequested>
+              <t:CalendarItemType>Single</t:CalendarItemType>
+              <t:MyResponseType>Organizer</t:MyResponseType>
+              <t:Organizer>
+                <t:Mailbox>
+                  <t:Name>{organizer.name}</t:Name>
+                  <t:EmailAddress>{organizer.email}</t:EmailAddress>
+                  <t:RoutingType>SMTP</t:RoutingType>
+                </t:Mailbox>
+              </t:Organizer>
+              <t:RequiredAttendees>
+                <t:Attendee>
+                  <t:Mailbox>
+                    <t:Name>{required_accepted.name}</t:Name>
+                    <t:EmailAddress>{required_accepted.email}</t:EmailAddress>
+                    <t:RoutingType>SMTP</t:RoutingType>
+                  </t:Mailbox>
+                  <t:ResponseType>{required_accepted.response}</t:ResponseType>
+                  <t:LastResponseTime>{required_accepted.last_response:%Y-%m-%dT%H:%M:%SZ}</t:LastResponseTime>
+                </t:Attendee>
+                <t:Attendee>
+                  <t:Mailbox>
+                    <t:Name>{required_tentative.name}</t:Name>
+                    <t:EmailAddress>{required_tentative.email}</t:EmailAddress>
+                    <t:RoutingType>SMTP</t:RoutingType>
+                  </t:Mailbox>
+                  <t:ResponseType>{required_tentative.response}</t:ResponseType>
+                  <t:LastResponseTime>{required_tentative.last_response:%Y-%m-%dT%H:%M:%SZ}</t:LastResponseTime>
+                </t:Attendee>
+               <t:Attendee>
+                  <t:Mailbox>
+                    <t:Name>{required_declined.name}</t:Name>
+                    <t:EmailAddress>{required_declined.email}</t:EmailAddress>
+                    <t:RoutingType>SMTP</t:RoutingType>
+                  </t:Mailbox>
+                  <t:ResponseType>{required_declined.response}</t:ResponseType>
+                  <t:LastResponseTime>{required_declined.last_response:%Y-%m-%dT%H:%M:%SZ}</t:LastResponseTime>
+                </t:Attendee>
+                <t:Attendee>
+                  <t:Mailbox>
+                    <t:Name>{required_unknown.name}</t:Name>
+                    <t:EmailAddress>{required_unknown.email}</t:EmailAddress>
+                    <t:RoutingType>SMTP</t:RoutingType>
+                  </t:Mailbox>
+                  <t:ResponseType>{required_unknown.response}</t:ResponseType>
+                </t:Attendee>
+              </t:RequiredAttendees>
+              <t:OptionalAttendees>
+                <t:Attendee>
+                  <t:Mailbox>
+                    <t:Name>{optional_accepted.name}</t:Name>
+                    <t:EmailAddress>{optional_accepted.email}</t:EmailAddress>
+                    <t:RoutingType>SMTP</t:RoutingType>
+                  </t:Mailbox>
+                  <t:ResponseType>{optional_accepted.response}</t:ResponseType>
+                  <t:LastResponseTime>{optional_accepted.last_response:%Y-%m-%dT%H:%M:%SZ}</t:LastResponseTime>
+                </t:Attendee>
+                <t:Attendee>
+                  <t:Mailbox>
+                    <t:Name>{optional_tentative.name}</t:Name>
+                    <t:EmailAddress>{optional_tentative.email}</t:EmailAddress>
+                    <t:RoutingType>SMTP</t:RoutingType>
+                  </t:Mailbox>
+                  <t:ResponseType>{optional_tentative.response}</t:ResponseType>
+                  <t:LastResponseTime>{optional_tentative.last_response:%Y-%m-%dT%H:%M:%SZ}</t:LastResponseTime>
+                </t:Attendee>
+               <t:Attendee>
+                  <t:Mailbox>
+                    <t:Name>{optional_declined.name}</t:Name>
+                    <t:EmailAddress>{optional_declined.email}</t:EmailAddress>
+                    <t:RoutingType>SMTP</t:RoutingType>
+                  </t:Mailbox>
+                  <t:ResponseType>{optional_declined.response}</t:ResponseType>
+                  <t:LastResponseTime>{optional_declined.last_response:%Y-%m-%dT%H:%M:%SZ}</t:LastResponseTime>
+                </t:Attendee>
+                <t:Attendee>
+                  <t:Mailbox>
+                    <t:Name>{optional_unknown.name}</t:Name>
+                    <t:EmailAddress>{optional_unknown.email}</t:EmailAddress>
+                    <t:RoutingType>SMTP</t:RoutingType>
+                  </t:Mailbox>
+                  <t:ResponseType>{optional_unknown.response}</t:ResponseType>
+                </t:Attendee>
+              </t:OptionalAttendees>
+              <t:Resources>
+                <t:Attendee>
+                  <t:Mailbox>
+                    <t:Name>{resource.name}</t:Name>
+                    <t:EmailAddress>{resource.email}</t:EmailAddress>
+                    <t:RoutingType>SMTP</t:RoutingType>
+                  </t:Mailbox>
+                  <t:ResponseType>{resource.response}</t:ResponseType>
+                  <t:LastResponseTime>{resource.last_response:%Y-%m-%dT%H:%M:%SZ}</t:LastResponseTime>
+                </t:Attendee>
+              </t:Resources>
+
+              <t:ConflictingMeetingCount>1</t:ConflictingMeetingCount>
+              <t:AdjacentMeetingCount>1</t:AdjacentMeetingCount>
+              <t:ConflictingMeetings>
+                <t:CalendarItem>
+                  <t:ItemId Id="{conflict_event.id}" ChangeKey="{conflict_event.change_key}"/>
+                  <t:Subject>{conflict_event.subject}</t:Subject>
+                  <t:Start>{conflict_event.start:%Y-%m-%dT%H:%M:%SZ}</t:Start>
+                  <t:End>{conflict_event.end:%Y-%m-%dT%H:%M:%SZ}</t:End>
+                  <t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus>
+                  <t:Location>{conflict_event.location}</t:Location>
+                </t:CalendarItem>
+              </t:ConflictingMeetings>
+              <t:AdjacentMeetings>
+                <t:CalendarItem>
+                  <t:ItemId Id="dinosaur" ChangeKey="goesrarrr"/>
+                  <t:Subject>my other OTHER awesome event</t:Subject>
+                  <t:Start>{event.start:%Y-%m-%dT%H:%M:%SZ}</t:Start>
+                  <t:End>{event.end:%Y-%m-%dT%H:%M:%SZ}</t:End>
+                  <t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus>
+                  <t:Location>Outside</t:Location>
+                </t:CalendarItem>
+              </t:AdjacentMeetings>
+              <t:Duration>PT1H</t:Duration>
+              <t:TimeZone>(UTC-08:00) Pacific Time (US &amp; Canada)</t:TimeZone>
+              <t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber>
+              <t:AppointmentState>1</t:AppointmentState>
+            </t:CalendarItem>
+          </m:Items>
+        </m:GetItemResponseMessage>
+      </m:ResponseMessages>
+    </m:GetItemResponse>
+  </s:Body>
+</s:Envelope>
+""".format(event=TEST_EVENT,
+           organizer=ORGANIZER,
+           required_accepted=PERSON_REQUIRED_ACCEPTED,
+           required_tentative=PERSON_REQUIRED_TENTATIVE,
+           required_declined=PERSON_REQUIRED_DECLINED,
+           required_unknown=PERSON_REQUIRED_UNKNOWN,
+           optional_accepted=PERSON_OPTIONAL_ACCEPTED,
+           optional_tentative=PERSON_OPTIONAL_TENTATIVE,
+           optional_declined=PERSON_OPTIONAL_DECLINED,
+           optional_unknown=PERSON_OPTIONAL_UNKNOWN,
+           resource=RESOURCE,
+           conflict_event=TEST_CONFLICT_EVENT,
+           attachment_id1=ATTACHMENT_IDS[0],
+           attachment_id2=ATTACHMENT_IDS[1]
            )
 
 CONFLICTING_EVENTS_RESPONSE = u"""<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">

--- a/tests/exchange2010/test_add_attachment.py
+++ b/tests/exchange2010/test_add_attachment.py
@@ -1,0 +1,107 @@
+"""
+(c) 2013 LinkedIn Corp. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");?you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software?distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+"""
+import pickle
+import unittest
+from httpretty import HTTPretty, httprettified
+from pytest import raises
+from pyexchange import Exchange2010Service
+
+from pyexchange.connection import ExchangeNTLMAuthConnection
+from pyexchange.base.calendar import ExchangeEventAttendee
+from pyexchange.exceptions import *  # noqa
+from pyexchange.exchange2010 import Exchange2010Attachment
+
+from .fixtures import *  # noqa
+
+config = {
+  "username": FAKE_EXCHANGE_USERNAME,
+  "password": FAKE_EXCHANGE_PASSWORD,
+  "url": FAKE_EXCHANGE_URL
+}
+
+
+class Test_AddingAnAttachment(unittest.TestCase):
+  calendar = None
+
+  @httprettified
+  def setUp(self):
+    self.calendar = Exchange2010Service(
+      connection=ExchangeNTLMAuthConnection(
+        **config
+      )
+    ).calendar()
+
+    HTTPretty.register_uri(
+      HTTPretty.POST,
+      FAKE_EXCHANGE_URL,
+      body=GET_ITEM_RESPONSE.encode('utf-8'),
+      content_type='text/xml; charset=utf-8'
+    )
+
+    self.event = self.calendar.get_event(id=TEST_EVENT_ATTACHED.id)
+    self.event._change_key = TEST_EVENT_ATTACHED.change_key
+
+  @httprettified
+  def test_can_add_from_valid_base64(self):
+    HTTPretty.register_uri(
+      HTTPretty.POST, FAKE_EXCHANGE_URL,
+      body=CREATE_ATTACHMENT_RESPONSE.encode('utf-8'),
+      content_type='text/xml; charset=utf-8',
+    )
+    att = self.event.add_attachment(ATTACHMENT_NAME, b64_data=VALID_BASE64)
+
+    # Should be an attachment
+    assert isinstance(att, Exchange2010Attachment)
+    # Shouldn't be loaded
+    assert att._loaded == False
+
+  @httprettified
+  def test_can_add_from_file_like_object(self):
+    HTTPretty.register_uri(
+      HTTPretty.POST, FAKE_EXCHANGE_URL,
+      body=CREATE_ATTACHMENT_RESPONSE.encode('utf-8'),
+      content_type='text/xml; charset=utf-8',
+    )
+    self.event.add_attachment(ATTACHMENT_NAME, file=READABLE_FILE)
+
+  @httprettified
+  def test_should_call_update_key_if_not_available(self):
+    # TODO pick a mock library instead
+    m = self.event.refresh_change_key
+    calls = []
+    def been_called():
+      calls.append('Called it!')
+      self.event._change_key = TEST_EVENT_ATTACHED.change_key
+
+    self.event.refresh_change_key = been_called
+    self.event._change_key = None
+    HTTPretty.register_uri(
+      HTTPretty.POST, FAKE_EXCHANGE_URL,
+      body=CREATE_ATTACHMENT_RESPONSE.encode('utf-8'),
+      content_type='text/xml; charset=utf-8',
+    )
+
+    self.event.add_attachment(ATTACHMENT_NAME, file=READABLE_FILE)
+    self.event.refresh_change_key = m
+
+    assert calls.__len__() > 0
+
+  def test_cant_have_empty_name(self):
+    with raises(ValueError):
+      self.event.add_attachment('', b64_data=VALID_BASE64)
+
+  def test_needs_either_file_or_b64(self):
+    with raises(ValueError):
+      self.event.add_attachment(ATTACHMENT_NAME)
+
+  def test_fails_with_invalid_base64(self):
+    with raises(TypeError):
+      self.event.add_attachment(ATTACHMENT_NAME, b64_data=INVALID_BASE64)
+
+  def test_fails_with_non_existing_file(self):
+    with raises(IOError):
+      self.event.add_attachment(ATTACHMENT_NAME, file='some_random_file_name')

--- a/tests/exchange2010/test_add_attachment.py
+++ b/tests/exchange2010/test_add_attachment.py
@@ -86,9 +86,15 @@ class Test_AddingAnAttachment(unittest.TestCase):
     )
 
     self.event.add_attachment(ATTACHMENT_NAME, file=READABLE_FILE)
+    # Put back to original
     self.event.refresh_change_key = m
 
     assert calls.__len__() > 0
+
+  def test_cant_add_to_not_yet_created_event(self):
+    self.event._id = None
+    with raises(TypeError):
+        self.event.add_attachment('name', b64_data=VALID_BASE64)
 
   def test_cant_have_empty_name(self):
     with raises(ValueError):

--- a/tests/exchange2010/test_add_attachment.py
+++ b/tests/exchange2010/test_add_attachment.py
@@ -4,14 +4,12 @@ Licensed under the Apache License, Version 2.0 (the "License");?you may not use 
 
 Unless required by applicable law or agreed to in writing, software?distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
-import pickle
 import unittest
 from httpretty import HTTPretty, httprettified
 from pytest import raises
 from pyexchange import Exchange2010Service
 
 from pyexchange.connection import ExchangeNTLMAuthConnection
-from pyexchange.base.calendar import ExchangeEventAttendee
 from pyexchange.exceptions import *  # noqa
 from pyexchange.exchange2010 import Exchange2010Attachment
 
@@ -57,7 +55,7 @@ class Test_AddingAnAttachment(unittest.TestCase):
     # Should be an attachment
     assert isinstance(att, Exchange2010Attachment)
     # Shouldn't be loaded
-    assert att._loaded == False
+    assert att._loaded is False
 
   @httprettified
   def test_can_add_from_file_like_object(self):
@@ -73,6 +71,7 @@ class Test_AddingAnAttachment(unittest.TestCase):
     # TODO pick a mock library instead
     m = self.event.refresh_change_key
     calls = []
+
     def been_called():
       calls.append('Called it!')
       self.event._change_key = TEST_EVENT_ATTACHED.change_key

--- a/tests/exchange2010/test_add_attachment.py
+++ b/tests/exchange2010/test_add_attachment.py
@@ -67,6 +67,20 @@ class Test_AddingAnAttachment(unittest.TestCase):
     self.event.add_attachment(ATTACHMENT_NAME, file=READABLE_FILE)
 
   @httprettified
+  def test_can_add_from_file_path(self):
+    HTTPretty.register_uri(
+      HTTPretty.POST, FAKE_EXCHANGE_URL,
+      body=CREATE_ATTACHMENT_RESPONSE.encode('utf-8'),
+      content_type='text/xml; charset=utf-8',
+    )
+    # Create temp file
+    import tempfile
+    with tempfile.NamedTemporaryFile(delete=True) as t:
+      t.write(b'some stuff')
+      t.seek(0)
+      self.event.add_attachment(ATTACHMENT_NAME, file=t.name)
+
+  @httprettified
   def test_should_call_update_key_if_not_available(self):
     # TODO pick a mock library instead
     m = self.event.refresh_change_key

--- a/tests/exchange2010/test_delete_attachment.py
+++ b/tests/exchange2010/test_delete_attachment.py
@@ -5,9 +5,8 @@ Licensed under the Apache License, Version 2.0 (the "License");?you may not use 
 Unless required by applicable law or agreed to in writing, software?distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
 import unittest
-from httpretty import HTTPretty, httprettified
+from httpretty import HTTPretty
 import httpretty
-from pytest import raises
 from pyexchange import Exchange2010Service
 
 from pyexchange.connection import ExchangeNTLMAuthConnection
@@ -52,4 +51,4 @@ class Test_DeletingAnAttachment(unittest.TestCase):
       content_type='text/xml; charset=utf-8'
     )
     self.attachment.delete()
-    assert ATTACHMENT_DETAILS.id in httpretty.last_request().body
+    assert ATTACHMENT_DETAILS.id in httpretty.last_request().body.decode('utf-8')

--- a/tests/exchange2010/test_delete_attachment.py
+++ b/tests/exchange2010/test_delete_attachment.py
@@ -1,0 +1,55 @@
+"""
+(c) 2013 LinkedIn Corp. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");?you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software?distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+"""
+import unittest
+from httpretty import HTTPretty, httprettified
+import httpretty
+from pytest import raises
+from pyexchange import Exchange2010Service
+
+from pyexchange.connection import ExchangeNTLMAuthConnection
+from pyexchange.exceptions import *  # noqa
+from pyexchange.exchange2010 import Exchange2010Attachment
+
+from .fixtures import *  # noqa
+
+config = {
+  "username": FAKE_EXCHANGE_USERNAME,
+  "password": FAKE_EXCHANGE_PASSWORD,
+  "url": FAKE_EXCHANGE_URL
+}
+
+
+class Test_DeletingAnAttachment(unittest.TestCase):
+  calendar = None
+
+  def setUp(self):
+    httpretty.enable()
+    self.service = Exchange2010Service(
+      connection=ExchangeNTLMAuthConnection(
+        **config
+      )
+    )
+
+    HTTPretty.register_uri(
+      HTTPretty.POST,
+      FAKE_EXCHANGE_URL,
+      body=GET_ATTACHMENT_RESPONSE.encode('utf-8'),
+      content_type='text/xml; charset=utf-8'
+    )
+
+    self.attachment = Exchange2010Attachment(self.service, ATTACHMENT_DETAILS.id, load=True)
+
+  def test_includes_id_into_post(self):
+    httpretty.enable()
+    HTTPretty.register_uri(
+      HTTPretty.POST,
+      FAKE_EXCHANGE_URL,
+      body=DELETE_ATTACHMENT_RESPONSE.encode('utf-8'),
+      content_type='text/xml; charset=utf-8'
+    )
+    self.attachment.delete()
+    assert ATTACHMENT_DETAILS.id in httpretty.last_request().body

--- a/tests/exchange2010/test_get_attachment.py
+++ b/tests/exchange2010/test_get_attachment.py
@@ -1,0 +1,72 @@
+"""
+(c) 2013 LinkedIn Corp. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");?you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software?distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+"""
+import pickle
+import unittest
+from httpretty import HTTPretty, httprettified
+from pytest import raises
+from pyexchange import Exchange2010Service
+
+from pyexchange.exchange2010 import Exchange2010Attachment
+from pyexchange.connection import ExchangeNTLMAuthConnection
+from pyexchange.base.calendar import ExchangeEventAttendee
+from pyexchange.exceptions import *  # noqa
+
+import logging
+logger = logging.getLogger("pyexchange")
+logger.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch = logging.StreamHandler()
+ch.setLevel(logging.DEBUG)
+ch.setFormatter(formatter)
+logger.addHandler(ch)
+fh = logging.FileHandler('test.log')
+fh.setLevel(logging.DEBUG)
+fh.setFormatter(formatter)
+logger.addHandler(fh)
+
+from .fixtures import *  # noqa
+
+config = {
+  "username": FAKE_EXCHANGE_USERNAME,
+  "password": FAKE_EXCHANGE_PASSWORD,
+  "url": FAKE_EXCHANGE_URL,
+}
+
+
+class Test_GettingAnAttachment(unittest.TestCase):
+  calendar = None
+
+  @classmethod
+  def setUpClass(cls):
+    cls.service = Exchange2010Service(
+      connection=ExchangeNTLMAuthConnection(
+        **config
+      )
+    )
+
+  @httprettified
+  def test_can_get_attachment(self):
+    HTTPretty.register_uri(
+      HTTPretty.POST, FAKE_EXCHANGE_URL,
+      body=GET_ATTACHMENT_RESPONSE.encode('utf-8'),
+      content_type='text/xml; charset=utf-8',
+    )
+    att = Exchange2010Attachment(self.service, ATTACHMENT_DETAILS.id)
+    assert att.content == ATTACHMENT_DETAILS.content
+    assert att.name == ATTACHMENT_DETAILS.name
+
+  @httprettified
+  def test_gets_sort_of_lazy_loaded(self):
+    HTTPretty.register_uri(
+      HTTPretty.POST, FAKE_EXCHANGE_URL,
+      body=GET_ATTACHMENT_RESPONSE.encode('utf-8'),
+      content_type='text/xml; charset=utf-8',
+    )
+    att = Exchange2010Attachment(self.service, ATTACHMENT_DETAILS.id)
+    assert att._loaded == False
+    content = att.content
+    assert att._loaded == True

--- a/tests/exchange2010/test_get_attachment.py
+++ b/tests/exchange2010/test_get_attachment.py
@@ -12,19 +12,6 @@ from pyexchange.exchange2010 import Exchange2010Attachment
 from pyexchange.connection import ExchangeNTLMAuthConnection
 from pyexchange.exceptions import *  # noqa
 
-import logging
-logger = logging.getLogger("pyexchange")
-logger.setLevel(logging.DEBUG)
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-ch = logging.StreamHandler()
-ch.setLevel(logging.DEBUG)
-ch.setFormatter(formatter)
-logger.addHandler(ch)
-fh = logging.FileHandler('test.log')
-fh.setLevel(logging.DEBUG)
-fh.setFormatter(formatter)
-logger.addHandler(fh)
-
 from .fixtures import *  # noqa
 
 config = {

--- a/tests/exchange2010/test_get_attachment.py
+++ b/tests/exchange2010/test_get_attachment.py
@@ -4,15 +4,12 @@ Licensed under the Apache License, Version 2.0 (the "License");?you may not use 
 
 Unless required by applicable law or agreed to in writing, software?distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
-import pickle
 import unittest
 from httpretty import HTTPretty, httprettified
-from pytest import raises
 from pyexchange import Exchange2010Service
 
 from pyexchange.exchange2010 import Exchange2010Attachment
 from pyexchange.connection import ExchangeNTLMAuthConnection
-from pyexchange.base.calendar import ExchangeEventAttendee
 from pyexchange.exceptions import *  # noqa
 
 import logging
@@ -67,6 +64,7 @@ class Test_GettingAnAttachment(unittest.TestCase):
       content_type='text/xml; charset=utf-8',
     )
     att = Exchange2010Attachment(self.service, ATTACHMENT_DETAILS.id)
-    assert att._loaded == False
-    content = att.content
-    assert att._loaded == True
+    assert att._loaded is False
+    # Simply causes to load
+    att.content
+    assert att._loaded is True

--- a/tests/exchange2010/test_get_event_with_attachments.py
+++ b/tests/exchange2010/test_get_event_with_attachments.py
@@ -1,0 +1,65 @@
+"""
+(c) 2013 LinkedIn Corp. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");?you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software?distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+"""
+import unittest
+from httpretty import HTTPretty, httprettified
+import httpretty
+from pyexchange import Exchange2010Service
+
+from pyexchange.exchange2010 import Exchange2010Attachment
+from pyexchange.connection import ExchangeNTLMAuthConnection
+from pyexchange.exceptions import *  # noqa
+
+from .fixtures import *  # noqa
+
+config = {
+  "username": FAKE_EXCHANGE_USERNAME,
+  "password": FAKE_EXCHANGE_PASSWORD,
+  "url": FAKE_EXCHANGE_URL
+}
+
+
+class Test_GettingAnEventWithAttachment(unittest.TestCase):
+
+  @httprettified
+  def setUp(self):
+    self.calendar = Exchange2010Service(
+      connection=ExchangeNTLMAuthConnection(
+        **config
+      )
+    ).calendar()
+
+  def test_sets_up_an_empty_array_if_no_attachments(self):
+    httpretty.enable()
+    HTTPretty.register_uri(
+      HTTPretty.POST,
+      FAKE_EXCHANGE_URL,
+      body=GET_ITEM_RESPONSE.encode('utf-8'),
+      content_type='text/xml; charset=utf-8'
+    )
+
+    event = self.calendar.get_event(id=TEST_EVENT.id)
+
+    assert event.attachments.__len__() == 0
+
+  def test_sets_up_correct_attachment_objects(self):
+    httpretty.enable()
+    HTTPretty.register_uri(
+      HTTPretty.POST,
+      FAKE_EXCHANGE_URL,
+      body=GET_ITEM_WITH_ATTACHMENTS_RESPONSE.encode('utf-8'),
+      content_type='text/xml; charset=utf-8'
+    )
+
+    event = self.calendar.get_event(id=TEST_EVENT.id)
+
+    # Two, as per fixture
+    assert event.attachments.__len__() == 2
+    # Of type Attachment object
+    for x in event.attachments:
+      assert type(x) == Exchange2010Attachment
+    # With the correct ids
+    assert set(ATTACHMENT_IDS) == set([x.id for x in event.attachments])

--- a/tests/exchange2010/test_list_events.py
+++ b/tests/exchange2010/test_list_events.py
@@ -2,6 +2,7 @@
 import unittest
 from pytest import raises
 from httpretty import HTTPretty, httprettified
+import httpretty
 from pyexchange import Exchange2010Service
 from pyexchange.connection import ExchangeNTLMAuthConnection
 from pyexchange.exceptions import *
@@ -23,8 +24,8 @@ class Test_ParseEventListResponseData(unittest.TestCase):
             )
         )
 
-    @httprettified
     def setUp(self):
+        httpretty.enable()
         HTTPretty.register_uri(
             HTTPretty.POST, FAKE_EXCHANGE_URL,
             body=LIST_EVENTS_RESPONSE.encode('utf-8'),
@@ -39,8 +40,8 @@ class Test_ParseEventListResponseData(unittest.TestCase):
         assert self.event_list is not None
 
     def test_dates_are_in_datetime_format(self):
-        assert 'StartDate="%s"' % TEST_EVENT_LIST_START.strftime(EXCHANGE_DATETIME_FORMAT) in HTTPretty.last_request.body.decode('utf-8')
-        assert 'EndDate="%s"' % TEST_EVENT_LIST_END.strftime(EXCHANGE_DATETIME_FORMAT) in HTTPretty.last_request.body.decode('utf-8')
+        assert 'StartDate="%s"' % TEST_EVENT_LIST_START.strftime(EXCHANGE_DATETIME_FORMAT) in httpretty.last_request().body.decode('utf-8')
+        assert 'EndDate="%s"' % TEST_EVENT_LIST_END.strftime(EXCHANGE_DATETIME_FORMAT) in httpretty.last_request().body.decode('utf-8')
 
     def test_event_count(self):
         assert self.event_list.count == 3


### PR DESCRIPTION
1. Allows to add an attachment to an existing event
2. Can take a base64 encoded string of bytes, a file path or a file-like object (anything that implements read and gives bytes)
3. Returns the (unloaded) attachment object
4. Allows to load the details of an attachment from their id
5. Uses a (weak) lazy load since content of file can be quite heavy. Loads name / content only when requested

Lots left to do on the feature:
1. When loading an event, create `Exchange2010Attachment` objects straight under the event.attahcments array
2. Updating attachments
3. Deleting attachments

Tested on 2.7 and 3.4

Would seek advise on documentation (where to insert examples for this)
Also, would like to use a mock library instead of httprettify if possible; please advise whether that's ok and which library you'd prefer if any.

Note that one of the existing tests is failing for me `test_list_events.test_dates_are_in_datetime_format` both in p3.4 and p2.7
